### PR TITLE
Fix #22

### DIFF
--- a/lib/pages/HomePage/widgets/PostCard.dart
+++ b/lib/pages/HomePage/widgets/PostCard.dart
@@ -79,7 +79,7 @@ class _PostCardState extends State<PostCard> {
                             height: deviceHeight * 0.32,
                             child: CachedNetworkImage(
                               imageUrl: widget.image,
-                              fit: BoxFit.fitWidth,
+                              fit: BoxFit.cover,
                               placeholder: (context, url) => Stack(
                                 alignment: Alignment.center,
                                 children: <Widget>[


### PR DESCRIPTION
This PR Fixes the issue #22 

All it needed was a better BoxFit.cover

This is the before 
![WhatsApp Image 2020-10-02 at 11 00 54 PM (1)](https://user-images.githubusercontent.com/47733983/94952267-54c26980-0503-11eb-9c28-5168192b1cbf.jpeg)

This is the after
![WhatsApp Image 2020-10-02 at 11 00 54 PM](https://user-images.githubusercontent.com/47733983/94952231-45dbb700-0503-11eb-84ab-bf26c384099b.jpeg)



## PS: 
I know the original issue had an screenshot of the Events page. Unfortunately I couldnt reach the Events page because of a firebase error. You may want to check that out.